### PR TITLE
No se permite asociar un pasajero a un booking ya publicado

### DIFF
--- a/src/main/java/acme/features/customer/bookingRecord/CustomerBookingRecordCreateService.java
+++ b/src/main/java/acme/features/customer/bookingRecord/CustomerBookingRecordCreateService.java
@@ -47,8 +47,10 @@ public class CustomerBookingRecordCreateService extends AbstractGuiService<Custo
 	@Override
 	public void validate(final BookingRecord br) {
 		if (br.getBooking() != null && br.getPassenger() != null) {
-			BookingRecord existing = this.repository.findByBookingIdAndPassengerId(br.getBooking().getId(), br.getPassenger().getId());
+			final BookingRecord existing = this.repository.findByBookingIdAndPassengerId(br.getBooking().getId(), br.getPassenger().getId());
 			super.state(existing == null, "passenger", "customer.booking-record.form.error.duplicate");
+
+			super.state(br.getBooking().isDraftMode(), "booking", "customer.booking-record.form.error.booking-published");
 		}
 	}
 
@@ -65,10 +67,9 @@ public class CustomerBookingRecordCreateService extends AbstractGuiService<Custo
 		SelectChoices passengerChoice;
 		Collection<Passenger> passengers;
 
-		Integer customer;
-		customer = super.getRequest().getPrincipal().getActiveRealm().getId();
+		final Integer customer = super.getRequest().getPrincipal().getActiveRealm().getId();
 
-		bookings = this.repository.findAllBookingsByCustomerId(customer);
+		bookings = this.repository.findDraftBookingsByCustomerId(customer);
 		bookingChoice = SelectChoices.from(bookings, "locatorCode", br.getBooking());
 
 		passengers = this.repository.findAllPassengersByCustomerId(customer);

--- a/src/main/java/acme/features/customer/bookingRecord/CustomerBookingRecordRepository.java
+++ b/src/main/java/acme/features/customer/bookingRecord/CustomerBookingRecordRepository.java
@@ -30,4 +30,7 @@ public interface CustomerBookingRecordRepository extends AbstractRepository {
 	@Query("SELECT br FROM BookingRecord br WHERE br.booking.id = :bookingId AND br.passenger.id = :passengerId")
 	BookingRecord findByBookingIdAndPassengerId(int bookingId, int passengerId);
 
+	@Query("select b from Booking b where b.customer.id = :customerId and b.draftMode = true")
+	Collection<Booking> findDraftBookingsByCustomerId(int customerId);
+
 }

--- a/src/main/java/acme/features/customer/bookingRecord/CustomerBookingRecordShowService.java
+++ b/src/main/java/acme/features/customer/bookingRecord/CustomerBookingRecordShowService.java
@@ -58,17 +58,24 @@ public class CustomerBookingRecordShowService extends AbstractGuiService<Custome
 		SelectChoices passengerChoice;
 		Collection<Passenger> passengers;
 
-		Integer customer;
-		customer = super.getRequest().getPrincipal().getActiveRealm().getId();
+		final Integer customer = super.getRequest().getPrincipal().getActiveRealm().getId();
 
-		bookings = this.repository.findAllBookingsByCustomerId(customer);
+		final java.util.List<Booking> draftBookings = new java.util.ArrayList<>(this.repository.findDraftBookingsByCustomerId(customer));
+
+		if (br.getBooking() != null && !br.getBooking().isDraftMode() && draftBookings.stream().noneMatch(b -> b.getId() == br.getBooking().getId()))
+			draftBookings.add(0, br.getBooking());
+
+		bookings = draftBookings;
 		bookingChoice = SelectChoices.from(bookings, "locatorCode", br.getBooking());
+
 		passengers = this.repository.findAllPassengersByCustomerId(customer);
 		passengerChoice = SelectChoices.from(passengers, "fullName", br.getPassenger());
 
 		dataset = super.unbindObject(br, "booking.locatorCode", "passenger.fullName", "draftMode");
 		dataset.put("bookingChoice", bookingChoice);
 		dataset.put("passengerChoice", passengerChoice);
+
 		super.getResponse().addData(dataset);
 	}
+
 }

--- a/src/main/resources/WEB-INF/views/customer/booking-record/messages-en.i18n
+++ b/src/main/resources/WEB-INF/views/customer/booking-record/messages-en.i18n
@@ -19,3 +19,4 @@ customer.bookingRecord.list.button.create = Create
 
 customer.booking-record.error.passenger-draft = The assigned passenger must be published.
 customer.booking-record.form.error.duplicate = This passenger is already associated with this reservation
+customer.booking-record.form.error.booking-published = It is not possible to assign passengers to a published reservation.

--- a/src/main/resources/WEB-INF/views/customer/booking-record/messages-es.i18n
+++ b/src/main/resources/WEB-INF/views/customer/booking-record/messages-es.i18n
@@ -19,3 +19,4 @@ customer.bookingRecord.list.button.create = Crear
 
 customer.booking-record.error.passenger-draft = El pasajero asignado debe estar publicado.
 customer.booking-record.form.error.duplicate = Este pasajero ya está asociado a esta reserva
+customer.booking-record.form.error.booking-published = No es posible asignar pasajeros a una reserva publicada.


### PR DESCRIPTION
Se ha solucionado el error de la revisión de la segunda convocatoria que permitía asociar un pasajero a una reserva ya publicada.
#235 